### PR TITLE
Make listen() in the plugin nonthreaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- For the plugin, make listen() nonthreaded 
 - Add `already_linear` flag, for already linearized data.
 - Add support for skipping flat fielding step.
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ SliceRecon is developed at Centrum Wiskunde & Informatica (CWI) in Amsterdam by:
 Also thanks to:
 
 - Willem Jan Palenstijn (@wjp)
+- Adriaan Graas (@adriaangraas)
 
 ## Contributing
 

--- a/include/slicerecon/servers/plugin.hpp
+++ b/include/slicerecon/servers/plugin.hpp
@@ -28,9 +28,6 @@ class plugin {
     ~plugin() { serve_thread_.join(); }
 
     void serve() {
-        util::log << LOG_FILE << util::lvl::info << "Plugin starts listening"
-                  << util::end_log;
-
         serve_thread_ = std::thread([&] {
             listen();
         });
@@ -56,6 +53,9 @@ class plugin {
     }
 
     void listen() {
+        util::log << LOG_FILE << util::lvl::info << "Plugin starts listening"
+                  << util::end_log;
+
         while (true) {
             zmq::message_t update;
             bool kill = false;


### PR DESCRIPTION
In hindsight, I think we can still release the GIL on both `listen()` and `serve()`.