### PR TITLE
Uninitialized flat field problem, sino buffer address type

### DIFF
--- a/src/reconstruction/reconstructor.cpp
+++ b/src/reconstruction/reconstructor.cpp
@@ -360,7 +360,7 @@ void reconstructor::initialize(acquisition::geometry geom) {
 
     buffer_[0].resize(parameters_.group_size * pixels_);
     buffer_[1].resize(parameters_.group_size * pixels_);
-    sino_buffer_.resize((long) geom_.rows * (long) geom_.cols * (long) parameters_.group_size);
+    sino_buffer_.resize((size_t) geom_.rows * (size_t) geom_.cols * (size_t) parameters_.group_size);
     small_volume_buffer_.resize(parameters_.preview_size *
                                 parameters_.preview_size *
                                 parameters_.preview_size);

--- a/src/reconstruction/reconstructor.cpp
+++ b/src/reconstruction/reconstructor.cpp
@@ -356,10 +356,11 @@ void reconstructor::initialize(acquisition::geometry geom) {
     all_flats_.resize(pixels_ * parameters_.flats);
     all_darks_.resize(pixels_ * parameters_.darks);
     dark_.resize(pixels_);
-    flat_fielder_.resize(pixels_);
+    flat_fielder_.resize(pixels_, 1);
+
     buffer_[0].resize(parameters_.group_size * pixels_);
     buffer_[1].resize(parameters_.group_size * pixels_);
-    sino_buffer_.resize(geom_.rows * geom_.cols * parameters_.group_size);
+    sino_buffer_.resize((long) geom_.rows * (long) geom_.cols * (long) parameters_.group_size);
     small_volume_buffer_.resize(parameters_.preview_size *
                                 parameters_.preview_size *
                                 parameters_.preview_size);


### PR DESCRIPTION
There are two minor problems hopefully fixed here.
- If no flats/darks have been sent, `flat_fielder_` remains zero-filled and the reconstructions never show up.
- `row * cols * group-size` may exceed the 32-bit type, become negative/incorrect, and cause a segfault. Is `long` the appropriate type?